### PR TITLE
fix(logging): use pino-pretty stream instead of transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,11 @@ import { rateLimit } from "elysia-rate-limit"
 
 const app = new Elysia()
   .use(rateLimit({ max: 30, duration: 2000, errorResponse: "Rate limit reached" }))
+  .get("/health", () => "Server is healthy")
   .use(swagger())
   .use(cors())
-  .use(Logger.middleware())
+  .use(Logger.fileMiddleware())
+  .use(Logger.streamMiddleware())
   .onError(({ error, code }) => {
     Logger.error("The server encountered an error", error)
 
@@ -23,7 +25,6 @@ const app = new Elysia()
       return "An unexpected error occurred"
     }
   })
-  .get("/health", () => "Server is healthy")
   .use(queue)
   .use(coordinator)
   .listen(env.PORT)

--- a/src/utils/logger.util.ts
+++ b/src/utils/logger.util.ts
@@ -1,16 +1,13 @@
 import { env } from "../config/env.config"
-import { createPinoLogger, fileLogger } from "@bogeychan/elysia-logger"
+import { createPinoLogger, fileLogger, logger } from "@bogeychan/elysia-logger"
+import pretty from "pino-pretty"
 
-const transportOptions = {
-  target: "pino-pretty",
-  options: {
-    colorize: true,
-  },
-}
-
-const log = createPinoLogger({
-  transport: transportOptions,
+const stream = pretty({
+  levelFirst: true,
+  colorize: true,
 })
+
+const log = createPinoLogger({ stream })
 
 /**
  * Logger class for logging messages with optional context and data.
@@ -31,11 +28,14 @@ export class Logger {
     this.context = context
   }
 
-  static middleware() {
+  static fileMiddleware() {
     return fileLogger({
       file: env.LOGFILE_NAME,
-      transport: transportOptions,
     })
+  }
+
+  static streamMiddleware() {
+    return logger({ stream })
   }
 
   static log(msg: string, data?: object) {


### PR DESCRIPTION
# Description

Testing [this workaround](https://stackoverflow.com/a/74100511) since `pino-pretty` may not be bundled in the final build.

- we will use `stream` instead of `transport`.
- separate file and stream logging.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code