### PR TITLE
feat(api/auth): integrate jwt auth into coordinators and queue endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ sqlite.db
 
 # drizzle
 drizzle
+
+# student ID text file
+/src/db/data/student-ids.txt

--- a/src/db/models/queue-number.model.ts
+++ b/src/db/models/queue-number.model.ts
@@ -4,6 +4,7 @@ import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
 
 export const queueNumbers = sqliteTable("queue_numbers", {
   id: integer("id").primaryKey({ autoIncrement: true }),
+  studentId: text("student_id").notNull(),
   courseName: text("course_name")
     .notNull()
     .references(() => courses.courseName, {

--- a/src/db/models/students.model.ts
+++ b/src/db/models/students.model.ts
@@ -1,0 +1,8 @@
+import { InferSelectModel } from "drizzle-orm"
+import { sqliteTable, text } from "drizzle-orm/sqlite-core"
+
+export const students = sqliteTable("students", {
+  id: text("student_id").notNull().primaryKey(),
+})
+
+export type SelectStudent = InferSelectModel<typeof students>

--- a/src/db/services/queue-number.service.ts
+++ b/src/db/services/queue-number.service.ts
@@ -33,11 +33,12 @@ export const queueNumberService: IQueueNumberService = {
 
     return { current, max }
   },
-  async enqueue(courseName: CourseNameEnum): Promise<QueueNumber> {
+  async enqueue(courseName: CourseNameEnum, studentId: string): Promise<QueueNumber> {
     const count = await db.$count(queueNumbers, eq(queueNumbers.courseName, courseName))
 
     const data: InsertQueueNumber = {
-      courseName: courseName,
+      studentId,
+      courseName,
       queueNumber: count + 1,
     }
 

--- a/src/db/services/queue-number.service.ts
+++ b/src/db/services/queue-number.service.ts
@@ -12,6 +12,14 @@ export const queueNumberService: IQueueNumberService = {
     return records
   },
 
+  async findByStudentId(studentId: string): Promise<QueueNumber> {
+    const records = await db.select().from(queueNumbers).where(eq(queueNumbers.studentId, studentId))
+
+    const record: SelectQueueNumber = records[0]
+
+    return record
+  },
+
   async findCurrentQueueByCourse(courseName: CourseNameEnum): Promise<{ current: number; max: number }> {
     const currentQueueRecord = await db
       .select()

--- a/src/db/services/queue-number.service.ts
+++ b/src/db/services/queue-number.service.ts
@@ -56,7 +56,7 @@ export const queueNumberService: IQueueNumberService = {
     return record
   },
 
-  async dequeue(courseName: CourseNameEnum): Promise<void> {
+  async dequeueFront(courseName: CourseNameEnum): Promise<void> {
     const currentQueueRecord = await db
       .select()
       .from(queueNumbers)
@@ -67,6 +67,10 @@ export const queueNumberService: IQueueNumberService = {
     const current: SelectQueueNumber = currentQueueRecord[0]
 
     await db.delete(queueNumbers).where(eq(queueNumbers.id, current.id))
+  },
+
+  async dequeueById(studentId: string): Promise<void> {
+    await db.delete(queueNumbers).where(eq(queueNumbers.studentId, studentId))
   },
 
   async resetAll(): Promise<void> {

--- a/src/db/services/student.service.ts
+++ b/src/db/services/student.service.ts
@@ -1,0 +1,15 @@
+import { db } from ".."
+import { IStudentService } from "../../types/abstracts/student-service.abstract"
+import { Student } from "../../types/entities/Student"
+import { SelectStudent, students } from "../models/students.model"
+import { eq } from "drizzle-orm"
+
+export const studentService: IStudentService = {
+  async findStudentById(studentId: string): Promise<Student> {
+    const records = await db.select().from(students).where(eq(students.id, studentId))
+
+    const record: SelectStudent = records[0]
+
+    return record
+  },
+}

--- a/src/db/utils/seed.ts
+++ b/src/db/utils/seed.ts
@@ -3,37 +3,78 @@ import { CoordinatorStatusEnum } from "../../types/enums/CoordinatorStatusEnum"
 import { coordinators } from "../models/coordinator.model"
 import { courses } from "../models/courses.model"
 import { queueNumbers } from "../models/queue-number.model"
+import { students } from "../models/students.model"
+import { readFile } from "fs/promises"
+import { join } from "path"
 
-// seed courses
-await db.insert(courses).values([{ courseName: "BSCS" }, { courseName: "BSIT" }, { courseName: "BSIS" }])
+async function seedDatabase() {
+  try {
+    // Read student IDs from txt file
+    const studentIdsText = await readFile(join(__dirname, "..", "data", "student-ids.txt"), "utf-8")
 
-// Seed queue numbers for each course
-const queueData = ["BSCS", "BSIT", "BSIS"].flatMap((courseName) => {
-  return Array.from({ length: 5 }, (_, index) => ({
-    courseName,
-    queueNumber: index + 1,
-  }))
-})
+    // Split the text file into an array of student IDs
+    const studentIds = studentIdsText
+      .split("\n")
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0)
 
-// Seed coordinators
-await db.insert(coordinators).values([
-  {
-    name: "Doriz Roa",
-    courseName: "BSCS",
-    status: CoordinatorStatusEnum.AVAILABLE,
-  },
-  {
-    name: "Gran Sabandal",
-    courseName: "BSIT",
-    status: CoordinatorStatusEnum.AVAILABLE,
-  },
-  {
-    name: "Glenn Pepito",
-    courseName: "BSIS",
-    status: CoordinatorStatusEnum.AVAILABLE,
-  },
-])
+    // Validate that we have enough student IDs
+    if (studentIds.length < 1500) {
+      throw new Error(`Not enough student IDs in file. Found ${studentIds.length}, need 1522`)
+    }
 
-await db.insert(queueNumbers).values(queueData)
+    // Begin seeding all tables
+    console.log("Starting database seeding...")
 
-console.log(`Seeding successful.`)
+    // Seed students table
+    const studentData = studentIds.map((id) => ({
+      id: id,
+    }))
+
+    await db.insert(students).values(studentData)
+    console.log("Seeded students table with 1522 records")
+
+    // Seed courses
+    await db.insert(courses).values([{ courseName: "BSCS" }, { courseName: "BSIT" }, { courseName: "BSIS" }])
+    console.log("Seeded courses table")
+
+    // Seed queue numbers for each course
+    const queueData = ["BSCS", "BSIT", "BSIS"].flatMap((courseName) => {
+      return Array.from({ length: 5 }, (_, index) => ({
+        studentId: `s${index + 1}`,
+        courseName,
+        queueNumber: index + 1,
+      }))
+    })
+
+    await db.insert(queueNumbers).values(queueData)
+    console.log("Seeded queue numbers")
+
+    // Seed coordinators
+    await db.insert(coordinators).values([
+      {
+        name: "Doriz Roa",
+        courseName: "BSCS",
+        status: CoordinatorStatusEnum.AVAILABLE,
+      },
+      {
+        name: "Gran Sabandal",
+        courseName: "BSIT",
+        status: CoordinatorStatusEnum.AVAILABLE,
+      },
+      {
+        name: "Glenn Pepito",
+        courseName: "BSIS",
+        status: CoordinatorStatusEnum.AVAILABLE,
+      },
+    ])
+    console.log("Seeded coordinators")
+
+    console.log("Database seeding completed successfully")
+  } catch (error) {
+    console.error("Error seeding database:", error)
+    throw error
+  }
+}
+
+seedDatabase().catch(console.error)

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -23,9 +23,7 @@ export const QueueTokenValidation = async (context: AuthMiddlewareContext): Prom
     return { message: "Queue Number Expired or Invalid Token" }
   }
 
-  console.log(context.headers)
-
-  context.headers.queueNumber = validToken.idNumber.toString()
+  context.headers.idNumber = validToken.idNumber.toString()
   context.headers.course = validToken.course
 }
 

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -2,7 +2,14 @@ import { HttpStatusEnum } from "../types/enums/HttpStatusEnum"
 import { AuthMiddlewareContext, QueueJwtPayload } from "../types/interfaces/JwtInterface"
 
 export const QueueTokenValidation = async (context: AuthMiddlewareContext): Promise<void | { message: string }> => {
-  const { authorization: token } = context.headers as { authorization?: string }
+  const { authorization } = context.headers as { authorization?: string }
+
+  if (!authorization) {
+    context.set.status = HttpStatusEnum.UNAUTHORIZED
+    return { message: "Unauthorized" }
+  }
+
+  const token = authorization.split(" ")[1]
 
   if (!token) {
     context.set.status = HttpStatusEnum.UNAUTHORIZED

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -23,6 +23,8 @@ export const QueueTokenValidation = async (context: AuthMiddlewareContext): Prom
     return { message: "Queue Number Expired or Invalid Token" }
   }
 
+  console.log(context.headers)
+
   context.headers.queueNumber = validToken.idNumber.toString()
   context.headers.course = validToken.course
 }

--- a/src/plugin/JwtPlugin.ts
+++ b/src/plugin/JwtPlugin.ts
@@ -11,8 +11,8 @@ export const jwtPlugin = new Elysia()
       name: "queueJwt",
       schema: JWTModel,
       secret: process.env.JWT_SECRET || "TEST SECRET KEY",
-      exp: JWTExpiry + "h", // It expires 5pm+
-      // exp: "1h", // testing
+      // exp: JWTExpiry + "h", // It expires 5pm+
+      exp: "1h", // testing
     }),
   )
   .derive({ as: "global" }, ({ queueJwt }) => {

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -19,18 +19,6 @@ export const auth = new Elysia({ prefix: "/auth" })
       }
     },
     {
-      async beforeHandle(context): Promise<void | { message: string }> {
-        if (context.headers.authorization) {
-          const token = context.headers.authorization.split(" ")[1]
-
-          const validToken = await context.queueJwt.verify(token)
-
-          if (validToken) {
-            context.set.status = HttpStatusEnum.BAD_REQUEST
-            return { message: "You are in a Queue Already!" }
-          }
-        }
-      },
       body: JWTModel,
     },
   )

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -21,7 +21,8 @@ export const auth = new Elysia({ prefix: "/auth" })
     {
       async beforeHandle(context): Promise<void | { message: string }> {
         if (context.headers.authorization) {
-          const token = context.headers.authorization
+          const token = context.headers.authorization.split(" ")[1]
+
           const validToken = await context.queueJwt.verify(token)
 
           if (validToken) {

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -1,3 +1,4 @@
+import { studentService } from "../db/services/student.service"
 import { jwtPlugin } from "../plugin/JwtPlugin"
 import { GetAuthQueueToken } from "../services/auth.service"
 import { JWTModel } from "../types/entities/dtos/JwtModel"
@@ -12,6 +13,18 @@ export const auth = new Elysia({ prefix: "/auth" })
   .post(
     "/sign-in",
     async ({ set, queueJwt, body }) => {
+      if (!body.idNumber || !body.course) {
+        set.status = HttpStatusEnum.BAD_REQUEST
+        return { message: "ID number and course are required" }
+      }
+
+      const student = await studentService.findStudentById(body.idNumber)
+
+      if (!student) {
+        set.status = HttpStatusEnum.BAD_REQUEST
+        return { message: "Student not found" }
+      }
+
       set.status = HttpStatusEnum.CREATED
       const token = await GetAuthQueueToken(queueJwt, body)
       return {

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -21,14 +21,25 @@ export const queue = new Elysia({ prefix: "/queue" })
   .use(jwtPlugin)
   .guard({
     params: "course",
-    beforeHandle: [QueueTokenValidation, CourseValidation],
   })
-  .post("/:course/number", async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
-    return await queueNumberService.enqueue(course)
-  })
-  .get("/:course/number/current", async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
-    return await queueNumberService.findCurrentQueueByCourse(course)
-  })
+  .post(
+    "/:course/number",
+    async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
+      return await queueNumberService.enqueue(course)
+    },
+    {
+      beforeHandle: [QueueTokenValidation, CourseValidation],
+    },
+  )
+  .get(
+    "/:course/number/current",
+    async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
+      return await queueNumberService.findCurrentQueueByCourse(course)
+    },
+    {
+      beforeHandle: [QueueTokenValidation, CourseValidation],
+    },
+  )
   .patch("/admin/:course/number/current", async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
     return await queueNumberService.dequeue(course)
   })

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -21,7 +21,6 @@ export const queue = new Elysia({ prefix: "/queue" })
   .use(jwtPlugin)
   .guard({
     params: "course",
-    /** Test Middleware Implementation : applies to all endpoints **/
     beforeHandle: [QueueTokenValidation, CourseValidation],
   })
   .post("/:course/number", async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -76,9 +76,9 @@ export const queue = new Elysia({ prefix: "/queue" })
     },
   )
 
-  .patch("/admin/:course/number/current", async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
+  .patch("/admin/:course/number/current", async ({ params: { course } }: QueueContext) => {
     return await queueNumberService.dequeueFront(course)
   })
-  .delete("/admin/:course/reset", ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
+  .delete("/admin/:course/reset", ({ params: { course } }: QueueContext) => {
     return queueNumberService.resetByCourse(course)
   })

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -25,7 +25,7 @@ export const queue = new Elysia({ prefix: "/queue" })
   .post(
     "/:course/number",
     async ({ params: { course } }: { params: { course: CourseNameEnum } }) => {
-      return await queueNumberService.enqueue(course)
+      return await queueNumberService.enqueue(course, "1")
     },
     {
       beforeHandle: [QueueTokenValidation, CourseValidation],

--- a/src/types/abstracts/queue-number-service.abstract.ts
+++ b/src/types/abstracts/queue-number-service.abstract.ts
@@ -3,6 +3,7 @@ import { CourseNameEnum } from "../enums/CourseNameEnum"
 
 export type IQueueNumberService = {
   findByCourse(courseName: CourseNameEnum): Promise<Partial<QueueNumber[]>>
+  findByStudentId(studentId: string): Promise<QueueNumber>
   findCurrentQueueByCourse(courseName: CourseNameEnum): Promise<{ current: number; max: number }>
   enqueue(courseName: CourseNameEnum, studentId: string): Promise<QueueNumber>
   dequeue(courseName: CourseNameEnum): Promise<void>

--- a/src/types/abstracts/queue-number-service.abstract.ts
+++ b/src/types/abstracts/queue-number-service.abstract.ts
@@ -4,7 +4,7 @@ import { CourseNameEnum } from "../enums/CourseNameEnum"
 export type IQueueNumberService = {
   findByCourse(courseName: CourseNameEnum): Promise<Partial<QueueNumber[]>>
   findCurrentQueueByCourse(courseName: CourseNameEnum): Promise<{ current: number; max: number }>
-  enqueue(courseName: CourseNameEnum): Promise<QueueNumber>
+  enqueue(courseName: CourseNameEnum, studentId: string): Promise<QueueNumber>
   dequeue(courseName: CourseNameEnum): Promise<void>
   resetAll(): Promise<void>
   resetByCourse(courseName: CourseNameEnum): Promise<void>

--- a/src/types/abstracts/queue-number-service.abstract.ts
+++ b/src/types/abstracts/queue-number-service.abstract.ts
@@ -6,7 +6,8 @@ export type IQueueNumberService = {
   findByStudentId(studentId: string): Promise<QueueNumber>
   findCurrentQueueByCourse(courseName: CourseNameEnum): Promise<{ current: number; max: number }>
   enqueue(courseName: CourseNameEnum, studentId: string): Promise<QueueNumber>
-  dequeue(courseName: CourseNameEnum): Promise<void>
+  dequeueFront(courseName: CourseNameEnum): Promise<void>
+  dequeueById(studentId: string): Promise<void>
   resetAll(): Promise<void>
   resetByCourse(courseName: CourseNameEnum): Promise<void>
 }

--- a/src/types/abstracts/student-service.abstract.ts
+++ b/src/types/abstracts/student-service.abstract.ts
@@ -1,0 +1,5 @@
+import { Student } from "../../types/entities/Student"
+
+export type IStudentService = {
+  findStudentById(studentId: string): Promise<Student>
+}

--- a/src/types/entities/QueueNumber.ts
+++ b/src/types/entities/QueueNumber.ts
@@ -1,5 +1,6 @@
 export type QueueNumber = {
   id: number
+  studentId: string
   courseName: string
   queueNumber: number
 }

--- a/src/types/entities/Student.ts
+++ b/src/types/entities/Student.ts
@@ -1,0 +1,3 @@
+export type Student = {
+  id: string
+}

--- a/src/types/entities/dtos/JwtModel.ts
+++ b/src/types/entities/dtos/JwtModel.ts
@@ -2,6 +2,6 @@ import { CourseUnion } from "./CourseUnion"
 import { t } from "elysia"
 
 export const JWTModel = t.Object({
-  idNumber: t.Number(),
+  idNumber: t.String(),
   course: CourseUnion,
 })

--- a/src/types/interfaces/JwtInterface.ts
+++ b/src/types/interfaces/JwtInterface.ts
@@ -3,7 +3,7 @@ import { JWTPayloadSpec } from "@elysiajs/jwt"
 import { StatusMap } from "elysia"
 
 export interface QueueJwtPayload extends JWTPayloadSpec {
-  idNumber: number
+  idNumber: string
   course: CourseNameEnum
 }
 


### PR DESCRIPTION
# Description
- Create `students` table
- Fix broken auth middlewares
- Seed `students` table with all DCISM student IDs stored in the [student-ids.txt file](https://github.com/orgs/usc-cisco/projects/3?pane=issue&itemId=93321165)
- reconcile jwt auth with newly created `students` table
- integrate auth with `coordinators` and `queue` endpoints
- handle edge cases such as duplicate queues and access to endpoints from different courses
- create endpoint for students to dequeue themselves

Fixes #5 #34

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.

## Screenshot of changes (if appropriate)

This is essentially what this PR does by cross-checking auth with the `students` table and disallowing duplicate queue numbers for 1 student ID

![image](https://github.com/user-attachments/assets/4ba6aa76-2b5a-492e-abe5-769ecadb179d)

