### PR TITLE
refactor: add OpenAPI docs to test & document routes, fixed publicity of some routes

### DIFF
--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -1,4 +1,6 @@
 export const env = {
   PORT: process.env.PORT || 3000,
   LOGFILE_NAME: process.env.LOGFILE_NAME || "./server.log",
+  JWT_SECRET: process.env.JWT_SECRET || "TEST SECRET KEY",
+  JWT_EXPIRY: Number(process.env.QUEUE_EXPIRY) - new Date().getHours(),
 }

--- a/src/db/services/queue-number.service.ts
+++ b/src/db/services/queue-number.service.ts
@@ -64,6 +64,11 @@ export const queueNumberService: IQueueNumberService = {
       .orderBy(asc(queueNumbers.queueNumber))
       .limit(1)
 
+    if (!currentQueueRecord) {
+      // Don't do anything if no queue numbers exists
+      return
+    }
+
     const current: SelectQueueNumber = currentQueueRecord[0]
 
     await db.delete(queueNumbers).where(eq(queueNumbers.id, current.id))

--- a/src/db/utils/seed.ts
+++ b/src/db/utils/seed.ts
@@ -15,7 +15,7 @@ async function seedDatabase() {
     // Split the text file into an array of student IDs
     const studentIds = studentIdsText
       .split("\n")
-      .map((id) => id.trim())
+      .map((id) => id.trim().replace("s", ""))
       .filter((id) => id.length > 0)
 
     // Validate that we have enough student IDs

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { rateLimit } from "elysia-rate-limit"
 
 const app = new Elysia()
   .use(rateLimit({ max: 30, duration: 2000, errorResponse: "Rate limit reached" }))
-  .get("/health", () => "Server is healthy", { tags: ["Debug"] })
+  .get("/health", () => "Server is healthy", { tags: ["Debug"], detail: { description: "Used for health checks." } })
   .use(
     swagger({
       documentation: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,19 @@ import { rateLimit } from "elysia-rate-limit"
 
 const app = new Elysia()
   .use(rateLimit({ max: 30, duration: 2000, errorResponse: "Rate limit reached" }))
-  .get("/health", () => "Server is healthy")
-  .use(swagger())
+  .get("/health", () => "Server is healthy", { tags: ["Debug"] })
+  .use(
+    swagger({
+      documentation: {
+        tags: [
+          { name: "Coordinator", description: "Methods related to viewing coordinator status & editing it" },
+          { name: "Queue", description: "Methods related to interacting with the queue" },
+          { name: "Auth", description: "Authentication endpoints" },
+          { name: "Debug", description: "Routes for debugging" },
+        ],
+      },
+    }),
+  )
   .use(cors())
   .use(Logger.fileMiddleware())
   .use(Logger.streamMiddleware())

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -26,3 +26,18 @@ export const validateQueueToken = async (context: AuthMiddlewareContext): Promis
   context.headers.idNumber = validToken.idNumber.toString()
   context.headers.course = validToken.course
 }
+
+// Validate if the user's requested course is equal to his registered queue course
+export const validateCourse = async (context: AuthMiddlewareContext): Promise<void | { message: string }> => {
+  const { course: headerCourse } = context.headers as { course?: string }
+
+  if (!headerCourse) {
+    context.set.status = HttpStatusEnum.BAD_REQUEST
+    return { message: "Course header is required" }
+  }
+
+  if (headerCourse !== context.params.course) {
+    context.set.status = HttpStatusEnum.UNAUTHORIZED
+    return { message: `You are not authorized to access ${context.params.course}` }
+  }
+}

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -1,7 +1,7 @@
 import { HttpStatusEnum } from "../types/enums/HttpStatusEnum"
 import { AuthMiddlewareContext, QueueJwtPayload } from "../types/interfaces/JwtInterface"
 
-export const QueueTokenValidation = async (context: AuthMiddlewareContext): Promise<void | { message: string }> => {
+export const validateQueueToken = async (context: AuthMiddlewareContext): Promise<void | { message: string }> => {
   const { authorization } = context.headers as { authorization?: string }
 
   if (!authorization) {
@@ -25,19 +25,4 @@ export const QueueTokenValidation = async (context: AuthMiddlewareContext): Prom
 
   context.headers.idNumber = validToken.idNumber.toString()
   context.headers.course = validToken.course
-}
-
-// Validate if the user's requested course is equal to his registered queue course
-export const CourseValidation = async (context: AuthMiddlewareContext): Promise<void | { message: string }> => {
-  const { course: headerCourse } = context.headers as { course?: string }
-
-  if (!headerCourse) {
-    context.set.status = HttpStatusEnum.BAD_REQUEST
-    return { message: "Course header is required" }
-  }
-
-  if (headerCourse !== context.params.course) {
-    context.set.status = HttpStatusEnum.UNAUTHORIZED
-    return { message: `You are not authorized to access ${context.params.course}` }
-  }
 }

--- a/src/plugin/JwtPlugin.ts
+++ b/src/plugin/JwtPlugin.ts
@@ -1,17 +1,15 @@
+import { env } from "../config/env.config"
 import { JWTModel } from "../types/entities/dtos/JwtModel"
 import { jwt } from "@elysiajs/jwt"
 import { Elysia } from "elysia"
-
-// Expires on EOD time - curr time
-const JWTExpiry = Number(process.env.QUEUE_EXPIRY) - new Date().getHours()
 
 export const jwtPlugin = new Elysia()
   .use(
     jwt({
       name: "queueJwt",
       schema: JWTModel,
-      secret: process.env.JWT_SECRET || "TEST SECRET KEY",
-      // exp: JWTExpiry + "h", // It expires 5pm+
+      secret: env.JWT_SECRET,
+      // exp: `${env.JWT_EXPIRY}h`, // It expires 5pm+
       exp: "1h", // testing
     }),
   )

--- a/src/plugin/JwtPlugin.ts
+++ b/src/plugin/JwtPlugin.ts
@@ -1,5 +1,5 @@
 import { env } from "../config/env.config"
-import { JWTModel } from "../types/entities/dtos/JwtModel"
+import { JwtModel } from "../types/entities/dtos/JwtModel"
 import { jwt } from "@elysiajs/jwt"
 import { Elysia } from "elysia"
 
@@ -7,12 +7,12 @@ export const jwtPlugin = new Elysia()
   .use(
     jwt({
       name: "queueJwt",
-      schema: JWTModel,
+      schema: JwtModel,
       secret: env.JWT_SECRET,
       // exp: `${env.JWT_EXPIRY}h`, // It expires 5pm+
       exp: "1h", // testing
     }),
   )
   .derive({ as: "global" }, ({ queueJwt }) => {
-    return { queueJwt: queueJwt }
+    return { queueJwt }
   })

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -1,13 +1,13 @@
 import { studentService } from "../db/services/student.service"
 import { jwtPlugin } from "../plugin/JwtPlugin"
-import { GetAuthQueueToken } from "../services/auth.service"
-import { JWTModel } from "../types/entities/dtos/JwtModel"
+import { getAuthToken } from "../services/auth.service"
+import { JwtModel } from "../types/entities/dtos/JwtModel"
 import { HttpStatusEnum } from "../types/enums/HttpStatusEnum"
 import Elysia from "elysia"
 
 export const auth = new Elysia({ prefix: "/auth" })
   .model({
-    JWTModel,
+    JwtModel,
   })
   .use(jwtPlugin)
   .post(
@@ -26,12 +26,50 @@ export const auth = new Elysia({ prefix: "/auth" })
       }
 
       set.status = HttpStatusEnum.CREATED
-      const token = await GetAuthQueueToken(queueJwt, body)
+      const token = await getAuthToken(queueJwt, body)
       return {
         token,
       }
     },
     {
-      body: JWTModel,
+      body: JwtModel,
+      detail: {
+        tags: ["Auth"],
+        description: "Use this to validate a student ID and create a JWT for validateQueueToken routes",
+        responses: {
+          "201": {
+            description: "JWT successfully created.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    token: {
+                      type: "string",
+                      description: "The generated JWT token.",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad request. Missing or invalid parameters, or student not found.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    message: {
+                      type: "string",
+                      description: "Error message describing the issue.",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   )

--- a/src/routers/coordinator.router.ts
+++ b/src/routers/coordinator.router.ts
@@ -1,6 +1,4 @@
 import { coordinatorService } from "../db/services/coordinator.service"
-import { CourseValidation, QueueTokenValidation } from "../middleware/authMiddleware"
-import { jwtPlugin } from "../plugin/JwtPlugin"
 import { CourseUnion } from "../types/entities/dtos/CourseUnion"
 import { StatusUnion } from "../types/entities/dtos/StatusUnion"
 import { CoordinatorStatusEnum } from "../types/enums/CoordinatorStatusEnum"
@@ -32,19 +30,12 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
       status: StatusUnion,
     }),
   })
-  .use(jwtPlugin)
   .guard({
     params: "course",
   })
-  .get(
-    "/:course",
-    async ({ params: { course } }: CoordinatorContext) => {
-      return await coordinatorService.findCoordinatorByCourse(course)
-    },
-    {
-      beforeHandle: [QueueTokenValidation, CourseValidation],
-    },
-  )
+  .get("/:course", async ({ params: { course } }: CoordinatorContext) => {
+    return await coordinatorService.findCoordinatorByCourse(course)
+  })
   .patch(
     "/admin/:course/coordinator/status",
     async ({ body, params: { course } }: CoordinatorContext) => {

--- a/src/routers/coordinator.router.ts
+++ b/src/routers/coordinator.router.ts
@@ -33,9 +33,15 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
   .guard({
     params: "course",
   })
-  .get("/:course", async ({ params: { course } }: CoordinatorContext) => {
-    return await coordinatorService.findCoordinatorByCourse(course)
-  })
+  .get(
+    "/:course",
+    async ({ params: { course } }: CoordinatorContext) => {
+      return await coordinatorService.findCoordinatorByCourse(course)
+    },
+    {
+      tags: ["Coordinator"],
+    },
+  )
   .patch(
     "/admin/:course/coordinator/status",
     async ({ body, params: { course } }: CoordinatorContext) => {
@@ -43,5 +49,6 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
     },
     {
       body: "newStatus",
+      tags: ["Coordinator"],
     },
   )

--- a/src/routers/coordinator.router.ts
+++ b/src/routers/coordinator.router.ts
@@ -40,6 +40,39 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
     },
     {
       tags: ["Coordinator"],
+      detail: {
+        description: "Gets the coordinator info & status of a specified course.",
+        responses: {
+          "200": {
+            description: "Successfully fetched the student's queue number.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    id: {
+                      type: "number",
+                      description: "The teacher's id. Not important.",
+                    },
+                    name: {
+                      type: "string",
+                      description: "The name of the coordinator.",
+                    },
+                    courseName: {
+                      type: "string",
+                      description: "CourseNameEnum (ie. BSCS | BSIT | BSIS)",
+                    },
+                    queueNumber: {
+                      type: "string",
+                      description: "CoordinatorStatusEnum (ie. available | away | unavailable)",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   )
   .patch(
@@ -50,5 +83,38 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
     {
       body: "newStatus",
       tags: ["Coordinator"],
+      detail: {
+        description: "Updates the coordinator status of a specified course.",
+        responses: {
+          "200": {
+            description: "Successfully updated the coordinator's status.",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    id: {
+                      type: "number",
+                      description: "The teacher's id. Not important.",
+                    },
+                    name: {
+                      type: "string",
+                      description: "The name of the coordinator.",
+                    },
+                    courseName: {
+                      type: "string",
+                      description: "CourseNameEnum (ie. BSCS | BSIT | BSIS)",
+                    },
+                    queueNumber: {
+                      type: "string",
+                      description: "CoordinatorStatusEnum (ie. available | away | unavailable)",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
     },
   )

--- a/src/routers/coordinator.router.ts
+++ b/src/routers/coordinator.router.ts
@@ -76,7 +76,7 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
     },
   )
   .patch(
-    "/admin/:course/coordinator/status",
+    "/admin/:course/status",
     async ({ body, params: { course } }: CoordinatorContext) => {
       return await coordinatorService.updateCoordinatorStatus(course, body.status)
     },

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -28,6 +28,15 @@ export const queue = new Elysia({ prefix: "/queue" })
       course: CourseUnion,
     }),
   })
+  .get(
+    "/:course/number/current",
+    async ({ params: { course } }: QueueContext) => {
+      return await queueNumberService.findCurrentQueueByCourse(course)
+    },
+    {
+      beforeHandle: [QueueTokenValidation, CourseValidation],
+    },
+  )
   .use(jwtPlugin)
   .delete(
     "/number",
@@ -61,15 +70,6 @@ export const queue = new Elysia({ prefix: "/queue" })
       if (await queueNumberService.findByStudentId(studentId)) return { message: "Student already has a queue number" }
 
       return await queueNumberService.enqueue(course, studentId)
-    },
-    {
-      beforeHandle: [QueueTokenValidation, CourseValidation],
-    },
-  )
-  .get(
-    "/:course/number/current",
-    async ({ params: { course } }: QueueContext) => {
-      return await queueNumberService.findCurrentQueueByCourse(course)
     },
     {
       beforeHandle: [QueueTokenValidation, CourseValidation],

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -1,5 +1,5 @@
 import { queueNumberService } from "../db/services/queue-number.service"
-import { validateQueueToken } from "../middleware/authMiddleware"
+import { validateCourse, validateQueueToken } from "../middleware/authMiddleware"
 import { jwtPlugin } from "../plugin/JwtPlugin"
 import { CourseUnion } from "../types/entities/dtos/CourseUnion"
 import { CourseNameEnum } from "../types/enums/CourseNameEnum"
@@ -173,7 +173,7 @@ export const queue = new Elysia({ prefix: "/queue" })
     },
     {
       params: "course",
-      beforeHandle: [validateQueueToken],
+      beforeHandle: [validateQueueToken, validateCourse],
       tags: ["Queue"],
       detail: {
         description: "Creates a queue number and associates the JWT student ID with it.",
@@ -213,6 +213,9 @@ export const queue = new Elysia({ prefix: "/queue" })
           },
           "400": {
             description: "Student already has a queue number.",
+          },
+          "401": {
+            description: "Student's is incorrectly trying to join another course's queue.",
           },
         },
       },

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -228,11 +228,24 @@ export const queue = new Elysia({ prefix: "/queue" })
       tags: ["Queue"],
       detail: {
         description: "Moves the queue forward by dequeuing the currently being served number.",
+        requestBody: {
+          required: false,
+          description: "No request body required. (!) Make sure to select None as the body type.",
+          content: {},
+        },
         security: [
           {
             basicAuth: [],
           },
         ],
+        responses: {
+          "200": {
+            description: "Successfully advanced the queue.",
+          },
+          "404": {
+            description: "Course used in :course parameter was not found.",
+          },
+        },
       },
     },
   )
@@ -251,6 +264,16 @@ export const queue = new Elysia({ prefix: "/queue" })
             basicAuth: [],
           },
         ],
+        requestBody: {
+          required: false,
+          description: "No request body required. (!) Make sure to select None as the body type.",
+          content: {},
+        },
+        responses: {
+          "200": {
+            description: "Successfully reset the course's queue.",
+          },
+        },
       },
     },
   )

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { JWTInterface, QueueJwtPayload } from "../types/interfaces/JwtInterface"
 
-export const GetAuthQueueToken = async (queueJwt: JWTInterface["queueJwt"], body: QueueJwtPayload) => {
+export const getAuthToken = async (queueJwt: JWTInterface["queueJwt"], body: QueueJwtPayload) => {
   const token = await queueJwt.sign(body)
 
   return token

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,6 +1,6 @@
-import { JWTInterface, QueueJwtPayload } from "../types/interfaces/JwtInterface"
+import { JwtInterface, QueueJwtPayload } from "../types/interfaces/JwtInterface"
 
-export const getAuthToken = async (queueJwt: JWTInterface["queueJwt"], body: QueueJwtPayload) => {
+export const getAuthToken = async (queueJwt: JwtInterface["queueJwt"], body: QueueJwtPayload) => {
   const token = await queueJwt.sign(body)
 
   return token

--- a/src/types/entities/dtos/JwtModel.ts
+++ b/src/types/entities/dtos/JwtModel.ts
@@ -1,7 +1,7 @@
 import { CourseUnion } from "./CourseUnion"
 import { t } from "elysia"
 
-export const JWTModel = t.Object({
+export const JwtModel = t.Object({
   idNumber: t.String(),
   course: CourseUnion,
 })

--- a/src/types/interfaces/JwtInterface.ts
+++ b/src/types/interfaces/JwtInterface.ts
@@ -7,14 +7,14 @@ export interface QueueJwtPayload extends JWTPayloadSpec {
   course: CourseNameEnum
 }
 
-export interface JWTInterface {
+export interface JwtInterface {
   queueJwt: {
     sign: (payload: QueueJwtPayload & JWTPayloadSpec) => Promise<string>
     verify: (payload: string) => Promise<JWTPayloadSpec | false>
   }
 }
 
-export interface AuthMiddlewareContext extends JWTInterface {
+export interface AuthMiddlewareContext extends JwtInterface {
   set: {
     status?: number | keyof StatusMap
   }


### PR DESCRIPTION
# Description

> [!Caution]
> I still can't find a way to remove the default JSON body in Scalar, so we kinda have to deal with that.

- added a route for a student to check their own student number
- refactored naming conventions for consistency
- added OpenAPI specs for better Swagger docs
  - tag routes
  - add descriptions
  - test routes for base functionality
- add env example file
- publicize `GET /queue/:course/number/current` and `GET /coordinator/:course` since you don't need to be authenticated here
- improve error handling for some services

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code

## Screenshot of changes (if appropriate)
![image](https://github.com/user-attachments/assets/7aa622ff-b3bd-4e9a-86f4-88a3c6e29fa8)
