### PR TITLE
fix: make all global error handlers return the proper HTTP status code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { queue } from "./routers/queue.router"
 import { Logger } from "./utils/logger.util"
 import { cors } from "@elysiajs/cors"
 import { swagger } from "@elysiajs/swagger"
-import { Elysia } from "elysia"
+import { Elysia, error as elysiaError } from "elysia"
 import { rateLimit } from "elysia-rate-limit"
 
 const app = new Elysia()
@@ -54,13 +54,13 @@ const app = new Elysia()
     Logger.error("The server encountered an error", error)
 
     if (code === "NOT_FOUND") {
-      return "Not found"
+      return elysiaError(404, "Not found")
     } else if (code === "VALIDATION") {
-      return error.validator.Errors(error.value).First().message
+      return elysiaError(400, error.validator.Errors(error.value).First().message)
     } else if (code === "BASIC_AUTH_ERROR") {
-      return "Unauthorized"
+      return elysiaError(403, "Unauthorized")
     } else {
-      return "An unexpected error occurred"
+      return elysiaError(500, "An unexpected error occurred")
     }
   })
   .use(queue)

--- a/src/routers/coordinator.router.ts
+++ b/src/routers/coordinator.router.ts
@@ -114,6 +114,9 @@ export const coordinator = new Elysia({ prefix: "/coordinator" })
               },
             },
           },
+          "403": {
+            description: "You did not set the correct Basic Auth header.",
+          },
         },
       },
     },


### PR DESCRIPTION
# Description

- make `BASIC_AUTH_ERROR` return the proper HTTP status code
- add error code docs for coordinator admin route

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist before requesting a review

- [x] I have performed a self-review of my code