### PR TITLE
feat: add studentId to current queue number GET route

### DIFF
--- a/src/db/services/queue-number.service.ts
+++ b/src/db/services/queue-number.service.ts
@@ -20,7 +20,9 @@ export const queueNumberService: IQueueNumberService = {
     return record
   },
 
-  async findCurrentQueueByCourse(courseName: CourseNameEnum): Promise<{ current: number; max: number }> {
+  async findCurrentQueueByCourse(
+    courseName: CourseNameEnum,
+  ): Promise<{ current: number; max: number; currentStudentId: string | null }> {
     const currentQueueRecord = await db
       .select()
       .from(queueNumbers)
@@ -29,6 +31,7 @@ export const queueNumberService: IQueueNumberService = {
       .limit(1)
 
     const current: number = currentQueueRecord.length ? currentQueueRecord[0].queueNumber : 0
+    const currentStudentId = currentQueueRecord.length ? currentQueueRecord[0].studentId : null
 
     const maxQueueRecord = await db
       .select()
@@ -39,7 +42,7 @@ export const queueNumberService: IQueueNumberService = {
 
     const max: number = maxQueueRecord.length ? maxQueueRecord[0].queueNumber : 0
 
-    return { current, max }
+    return { current, max, currentStudentId }
   },
   async enqueue(courseName: CourseNameEnum, studentId: string): Promise<QueueNumber> {
     const maxQueueRecord = await db

--- a/src/routers/queue.router.ts
+++ b/src/routers/queue.router.ts
@@ -126,7 +126,7 @@ export const queue = new Elysia({ prefix: "/queue" })
       params: "course",
       tags: ["Queue"],
       detail: {
-        description: "Gets the queue status of a course.",
+        description: "Gets the queue status of a course & the student ID to be served.",
         responses: {
           "200": {
             description: "Successfully fetched the queue status.",
@@ -142,6 +142,12 @@ export const queue = new Elysia({ prefix: "/queue" })
                     max: {
                       type: "number",
                       description: "The largest queue number.",
+                    },
+                    currentStudentId: {
+                      type: "string",
+                      nullable: true,
+                      description:
+                        "The student ID of the current queue number, otherwise null if no queue number exists.",
                     },
                   },
                 },

--- a/src/types/abstracts/queue-number-service.abstract.ts
+++ b/src/types/abstracts/queue-number-service.abstract.ts
@@ -4,7 +4,9 @@ import { CourseNameEnum } from "../enums/CourseNameEnum"
 export type IQueueNumberService = {
   findByCourse(courseName: CourseNameEnum): Promise<Partial<QueueNumber[]>>
   findByStudentId(studentId: string): Promise<QueueNumber>
-  findCurrentQueueByCourse(courseName: CourseNameEnum): Promise<{ current: number; max: number }>
+  findCurrentQueueByCourse(
+    courseName: CourseNameEnum,
+  ): Promise<{ current: number; max: number; currentStudentId: string | null }>
   enqueue(courseName: CourseNameEnum, studentId: string): Promise<QueueNumber>
   dequeueFront(courseName: CourseNameEnum): Promise<void>
   dequeueById(studentId: string): Promise<void>


### PR DESCRIPTION
# Description

- adds `currentStudentId` to the `GET /queue/:course/number/current` route

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code

## Screenshot of changes (if appropriate)
![image](https://github.com/user-attachments/assets/3ca71eef-bd3e-4b41-926b-1ce2e01fd360)
![image](https://github.com/user-attachments/assets/be4277d8-2367-4824-90a5-526e3cff7b43)
