### PR TITLE
feat(coordinator): add cutoff status enum

### DIFF
--- a/src/db/services/coordinator.service.ts
+++ b/src/db/services/coordinator.service.ts
@@ -35,7 +35,7 @@ export const coordinatorService: ICoordinatorService = {
   async updateCoordinatorStatus(courseName: CourseNameEnum, status: CoordinatorStatusEnum): Promise<Coordinator> {
     const records = await db
       .update(coordinators)
-      .set({ status: status })
+      .set({ status })
       .where(eq(coordinators.courseName, courseName))
       .returning()
 

--- a/src/db/services/queue-number.service.ts
+++ b/src/db/services/queue-number.service.ts
@@ -55,7 +55,7 @@ export const queueNumberService: IQueueNumberService = {
 
     const queuedStudents = currentQueueWithStudents.map((record) => ({
       queueNumber: record.queueNumber,
-      student: record.student.id ? record.student : null,
+      student: record.student?.id ? record.student : null,
     }))
 
     return {

--- a/src/types/entities/dtos/StatusUnion.ts
+++ b/src/types/entities/dtos/StatusUnion.ts
@@ -5,4 +5,5 @@ export const StatusUnion = t.Union([
   t.Literal(CoordinatorStatusEnum.AVAILABLE),
   t.Literal(CoordinatorStatusEnum.UNAVAILABLE),
   t.Literal(CoordinatorStatusEnum.AWAY),
+  t.Literal(CoordinatorStatusEnum.CUTOFF),
 ])

--- a/src/types/enums/CoordinatorStatusEnum.ts
+++ b/src/types/enums/CoordinatorStatusEnum.ts
@@ -2,4 +2,5 @@ export enum CoordinatorStatusEnum {
   AVAILABLE = "available",
   UNAVAILABLE = "unavailable",
   AWAY = "away",
+  CUTOFF = "cutoff",
 }


### PR DESCRIPTION
# Description

- add `cutoff` status enum
- enforce business logic to reject queue numbers based on coordinator status

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
